### PR TITLE
Add refreshReceipt API

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,13 @@ or empty `{ }` if productIds was an empty array.
 
 - *Return* failure with error as the only argument
 
+### refreshReceipt(Function success, Function failure)
+
+Refresh the receipt on iOS, do nothing on Android.
+
+- *Return* success
+- *Return* failure with error
+
 #### Security notes (Android)
 
 *** You (the developer) should verify that the orderId is a unique value that you have not previously processed, and the developerPayload string matches the token that you sent previously with the purchase request. As a further security precaution, you should perform the verification on your own secure server. ***
@@ -221,7 +228,7 @@ Failure callbacks return an error as an integer. See the following error table:
 |   22 | `INVALID_CLIENT`            | Indicates that the client is not allowed to perform the attempted action                               |
 |   23 | `INVALID_PAYMENT`           | Indicates that one of the payment parameters was not recognized                                        |
 |   24 | `UNAUTHORIZED`              | Indicates that the user is not allowed to authorise payments (e.g. parental lock)                      |
-|   24 | `RECEIPT_REFRESH_FAILED`    |                                                                                                        |
+|   25 | `RECEIPT_REFRESH_FAILED`    |                                                                                                        |
 
 ======
 Ref Links

--- a/src/android/WizPurchase.java
+++ b/src/android/WizPurchase.java
@@ -173,6 +173,9 @@ public class WizPurchase extends CordovaPlugin {
 		} else if (action.equalsIgnoreCase("finishPurchase")) {
 			finishPurchase(args, callbackContext);
 			return true;
+		} else if (action.equalsIgnoreCase("refreshReceipt")) {
+			callbackContext.success();
+			return true;
 		}
 		return false;
 	}

--- a/src/ios/WizPurchase.h
+++ b/src/ios/WizPurchase.h
@@ -57,5 +57,6 @@ typedef int CDVWizPurchaseError;
 - (void)finishPurchase:(CDVInvokedUrlCommand *)command;
 - (void)getPendingPurchases:(CDVInvokedUrlCommand *)command;
 - (void)restoreAllPurchases:(CDVInvokedUrlCommand *)command;
+- (void)refreshReceipt:(CDVInvokedUrlCommand *)command;
 
 @end

--- a/src/ios/WizPurchase.m
+++ b/src/ios/WizPurchase.m
@@ -185,6 +185,10 @@
     [receiptRefreshRequest start];
 }
 
+- (void)refreshReceipt:(CDVInvokedUrlCommand *)command {
+    [self refreshReceipt:command.callbackId result:[NSNull null]];
+}
+
 - (void)fetchProducts:(NSArray *)productIdentifiers {
     WizLog(@"Fetching product information");
     // Build a SKProductsRequest for the identifiers provided
@@ -214,6 +218,8 @@
             } else if ([result isKindOfClass:[NSArray class]]) {
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
                                                   messageAsArray:[self addReceiptToTransactionResults:receipt results:result]];
+            } else if ([result isEqual:[NSNull null]]) {
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
             }
             [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
         }
@@ -373,14 +379,14 @@
 
 - (void)paymentQueue:(SKPaymentQueue *)queue updatedTransactions:(NSArray *)transactions {
 
-	NSInteger errorCode = 0; // Set default unknown error
+    NSInteger errorCode = 0; // Set default unknown error
     NSString *error;
     for (SKPaymentTransaction *transaction in transactions) {
         
         switch (transaction.transactionState) {
-			case SKPaymentTransactionStatePurchasing:
+            case SKPaymentTransactionStatePurchasing:
                 WizLog(@"SKPaymentTransactionStatePurchasing");
-				break;
+                break;
             case SKPaymentTransactionStateDeferred:
                 WizLog(@"SKPaymentTransactionStateDeferred");
                 break;

--- a/www/WizPurchase.js
+++ b/www/WizPurchase.js
@@ -34,6 +34,10 @@ var WizPurchase = {
 
 	restoreAllPurchases: function (s, f) {
 		exec(s, f, "WizPurchase", "restoreAllPurchases", []);
+	},
+
+	refreshReceipt: function (s, f) {
+		exec(s, f, "WizPurchase", "refreshReceipt", []);
 	}
 };
 


### PR DESCRIPTION
## Minor
- Add `refreshReceipt` API to manually refresh the iOS receipt when needed (iOS)

poke @tbrebant @ronkorving 
